### PR TITLE
Bump shiro.version from 1.3.2 to 1.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <spring.version>4.2.0.RELEASE</spring.version>
     <lucene.version>7.6.0</lucene.version>
-    <shiro.version>1.3.2</shiro.version>
+    <shiro.version>1.5.1</shiro.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Bumps `shiro.version` from 1.3.2 to 1.5.2.

Updates `shiro-core` from 1.3.2 to 1.5.2
- [Release notes](https://github.com/apache/shiro/releases)
- [Changelog](https://github.com/apache/shiro/blob/master/RELEASE-NOTES)
- [Commits](https://github.com/apache/shiro/compare/shiro-root-1.3.2...shiro-root-1.5.1)

Updates `shiro-web` from 1.3.2 to 1.5.2
- [Release notes](https://github.com/apache/shiro/releases)
- [Changelog](https://github.com/apache/shiro/blob/master/RELEASE-NOTES)
- [Commits](https://github.com/apache/shiro/compare/shiro-root-1.3.2...shiro-root-1.5.1)

Updates `shiro-spring` from 1.3.2 to 1.5.2

Signed-off-by: dependabot[bot] <support@github.com>